### PR TITLE
docs: Debian/Ubuntu Package Installation section now uses parametric …

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -182,17 +182,22 @@ For Debian-based distributions, you can install using .deb packages.
 
 #### Download and Install
 ```bash
+# Get latest version info
+LATEST_VERSION=$(curl -s https://api.github.com/repos/Soar-Development/astir-installer/releases/latest | grep -o '"tag_name": "[^"]*' | cut -d'"' -f4)
+# Remove 'v' prefix for package naming
+VERSION=${LATEST_VERSION#v}
+
 # AMD64 (Intel/AMD 64-bit)
-wget https://github.com/Soar-Development/astir-installer/releases/latest/download/astir_latest_amd64.deb
-sudo dpkg -i astir_latest_amd64.deb
+wget "https://github.com/Soar-Development/astir-installer/releases/download/${LATEST_VERSION}/astir_${VERSION}_amd64.deb"
+sudo dpkg -i "astir_${VERSION}_amd64.deb"
 
 # ARM64 (64-bit ARM)
-wget https://github.com/Soar-Development/astir-installer/releases/latest/download/astir_latest_arm64.deb
-sudo dpkg -i astir_latest_arm64.deb
+wget "https://github.com/Soar-Development/astir-installer/releases/download/${LATEST_VERSION}/astir_${VERSION}_arm64.deb"
+sudo dpkg -i "astir_${VERSION}_arm64.deb"
 
 # ARMv7 (32-bit ARM)
-wget https://github.com/Soar-Development/astir-installer/releases/latest/download/astir_latest_armhf.deb
-sudo dpkg -i astir_latest_armhf.deb
+wget "https://github.com/Soar-Development/astir-installer/releases/download/${LATEST_VERSION}/astir_${VERSION}_armhf.deb"
+sudo dpkg -i "astir_${VERSION}_armhf.deb"
 ```
 
 #### Install Dependencies


### PR DESCRIPTION
The Debian/Ubuntu Package Installation section now uses parametric version selection that:

1. Fetches the latest version dynamically using the GitHub API (same as manual installation)
2. Removes the 'v' prefix from the version tag to match package naming conventions
3. Uses the actual versioned naming format
astir_${VERSION}_amd64.deb instead of the incorrect
astir_latest_amd64.deb